### PR TITLE
Use proper sections for doc index

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,27 +19,31 @@ data-driven investigations in petrology and volcanology.
 |
 
 
-
+Orange-Volcanoes
+----------------
 
 .. toctree::
    :maxdepth: 2
-   :caption: Orange-Volcanoes:
 
    introduction
    installing
    importing_data
 
+Tutorials
+---------
+
 .. toctree::
    :maxdepth: 2
-   :caption: Tutorials:  
-   
+
    coda_geochemistry
    tephra_clustering
    tephra_classification
 
+Widgets
+-------
+
 .. toctree::
    :maxdepth: 2
-   :caption: Widgets:  
 
    datasets
    data_cleaning


### PR DESCRIPTION
Without that (hidden in `:caption:`) Orange can not find the widgets. Orange's help looks for the "Widgets" section.

This is necessary but not sufficient to fix the docs. Submitting this separately because it will help me test more easily after it is built on readthedocs.